### PR TITLE
Added table for Review Committee

### DIFF
--- a/2023-2024-committee.html
+++ b/2023-2024-committee.html
@@ -1,0 +1,40 @@
+---
+layout: page
+---
+
+<!-- Team -->
+<section class="page-section" id="{{ site.data.sitetext[site.locale].team.section | default: "team" }}">
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-12 text-center">
+          <h2 class="section-heading text-uppercase">{{ site.data.sitetext[site.locale].committee.years[0].year}} Committee</h2>
+          <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].team.text }}</h3>
+        </div>
+      </div>
+      <div class="row">
+      {% for person in site.data.sitetext[site.locale].committee.years[0].people %}
+        <div class="col-sm-4">
+          <div class="team-member">
+            <img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
+            <h4>{{ person.name }}</h4>
+            <p class="text-muted">{{ person.role }}</p>
+            <ul class="list-inline social-buttons">
+            {% for network in person.social %}
+              <li class="list-inline-item">
+                <a href="mailto:{{ network.url }}">
+                  <i class="{{ network.icon }}"></i>
+                </a>
+              </li>
+            {% endfor %}
+            </ul>
+          </div>
+        </div>
+      {% endfor %}
+      </div>
+      <div class="row">
+        <div class="col-lg-8 mx-auto text-center">
+          <div class="large text-muted">{{ site.data.sitetext[site.locale].team.subtext | markdownify }}</div>
+        </div>
+      </div>
+    </div>
+    </section>

--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -369,6 +369,107 @@ en: &DEFAULT_EN
   footer:
     legal: "Privacy Policy"
 
+  committee:
+    years: 
+      - year: 2023-2024
+        people:
+        - name: "Chris Erdmann"
+          role: Associate Director for Open Science @ Michael J. Fox Foundation
+          image: assets/img/committee/c_erdmann.png
+          social: 
+            - url: christopher.c.erdmann@gmail.com
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/christopher-erdmann-1213a456/
+              icon: fab fa-linkedin-in
+
+        - name: "Cody Hennesy"
+          role: Journalism and Digital Media Librarian @ University of Minnesota
+          image: assets/img/committee/hennesy_2019_web-sml.png
+          social: 
+            - url: chennesy@umn.edu
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/cody-hennesy-8a915a117/
+              icon: fab fa-linkedin-in
+
+        - name: "Elaine Westbrooks"
+          role: Carl A. Kroch University Librarian @ Cornell University Library
+          image: assets/img/committee/ElaineWestBrooks-sml.png
+          social: 
+            - url: elw25@cornell.edu
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/elaine-w-13b1811/
+              icon: fab fa-linkedin-in
+
+        - name: "Caroline Coward"
+          role: Information Science Manager and Library Group Supervisor @ Jet Propulsion Lab, National Aeronautics and Space Administration
+          image: assets/img/committee/caroline-coward.png
+          social: 
+            - url: caroline.m.coward@jpl.nasa.gov
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/caroline-coward-nasa-jpl/
+              icon: fab fa-linkedin-in
+      
+        - name: "Yvonne Ivey"
+          role: Program Manager @ NAS TOPS
+          image: assets/img/committee/Yvonne.jpg
+          social: 
+            - url: ypivey@gmail.com
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/ypivey
+              icon: fab fa-linkedin-in
+        
+        - name: "Juliane Schneider"
+          role:  Research Librarian - Metadata @ Pacific Northwest National Laboratory 
+          image: assets/img/committee/juliane.jpg
+          social: 
+            - url: juliane.schneider@pnnl.gov
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/juliane-schneider-4a06535/
+              icon: fab fa-linkedin-in
+
+        - name: "Jenny Muilenburg"
+          role:  Research Data Services Librarian @ Association of Research Libraries
+          image: assets/img/committee/Jenny-Muilenburg-2015-web-sml.png
+          social: 
+            - url: jmuil@uw.edu
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/jennifermuilenburg/
+              icon: fab fa-linkedin-in
+
+        - name: "Clifford Kravit"
+          role: IT Program Manager of Research Computing @ UCLA
+          image: assets/img/committee/Clifford-Kravit.png
+          social: 
+            - url: ckravit@g.ucla.edu
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/clifford-kravit/
+              icon: fab fa-linkedin-in
+
+        - name: "Joy Guey"
+          role: Emerging Technologies Advocate @ UCLA
+          image: assets/img/committee/Joy.jpeg
+          social: 
+            - url: joy@ssc.ucla.edu
+              icon: fas fa-envelope
+            - url: https://www.linkedin.com/in/joyguey/
+              icon: fab fa-linkedin-in
+          
+        - name: "Florio Arguillas"
+          role: Researcher,  Cornell Center for Social Sciences
+          image: assets/img/committee/florio.jpg
+          social: 
+            - url: https://linkedin.com/in/florio-arguillas-06391310
+              icon: fab fa-linkedin-in
+              
+        - name: "Jane Greenberg"
+          role: Alice B. Kroeger Professor and Director, Metadata Research Center & Drexel University 
+          image: assets/img/committee/Greenberg_Small.jpg
+          social: 
+            - url: https://www.linkedin.com/in/jane-greenberg-b57b24128/
+              icon: fab fa-linkedin-in
+            - url: jg3243@drexel.edu
+              icon: fab fa-envelope
+
 en-US:
   <<: *DEFAULT_EN
 en-CA:

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -33,6 +33,35 @@
 	</div>
   </div>
 </div>
+
+<div>
+	<div class="container">
+        <div class="row">
+        <div class="col-lg-12 text-center">
+            <h2 class="section-heading text-uppercase"> Our Previous Committees </h2>
+            <!-- <h3 class="section-subheading text-muted"></h3> -->
+        </div>
+    </div>
+    </div>
+	<div class="container">
+		<div class="row">
+			<div class="col-lg-12">
+				<table class="table">
+					{% for year in site.data.sitetext[site.locale].committee.years %}
+					<tr>
+						<td>
+							{{year.year}}
+						</td>
+						<td>
+							<a href="/{{year.year}}-committee.html">{{year.year}} Review Committee</a>
+						</td>
+					</tr>
+					{% endfor %}
+				</table>
+			</div>
+		</div>
+	</div>
+</div>
 </section>
 <!-- End Team -->
 


### PR DESCRIPTION
Added a table under the committee to view past committees. It leads to a page that just displays the committee members for that calendar year. You need to add committee members to the site.text.yaml in order for it to display the members.

<img width="1512" alt="image" src="https://github.com/ucla-imls-open-sci/ucla-imls-open-sci.github.io/assets/104863284/c7133181-a31f-41ce-8712-9998df5d5497">


Committee Page:
<img width="1512" alt="image" src="https://github.com/ucla-imls-open-sci/ucla-imls-open-sci.github.io/assets/104863284/111d2d93-9a4d-4e2e-9b4c-3e23bf6aa52c">
