### PR TITLE
Improve pilot intake: canonical lessons, new fields, project auto-add

### DIFF
--- a/.github/ISSUE_TEMPLATE/pilot-interest.yml
+++ b/.github/ISSUE_TEMPLATE/pilot-interest.yml
@@ -1,20 +1,23 @@
 name: Pilot a Lesson (Beta Workshop Interest)
 description: Express interest in piloting an IMLS UCLA Open Science lesson
-title: "[Pilot Interest]: <Lesson title>"
+title: "[Pilot Interest]: "
 labels: ["pilot", "community", "beta"]
 assignees: ["jt14den"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for your interest in piloting an Open Science lesson for librarians.
-        This issue helps lesson authors and the project team coordinate beta pilot workshops.
+        Thanks for your interest in piloting an Open Science lesson for librarians.
+
+        **What a pilot is:** you teach one of our lessons to a real audience and tell us how it went. You do *not* need to be an expert in the topic — testing a lesson with an instructor who didn't write it is exactly what these materials need. Sessions run **1.5 to 4 hours** and can be a formal workshop or an informal brown-bag.
+
+        **What happens next:** we'll connect you with the lesson authors before your session, and you file a short [Pilot Report](https://github.com/ucla-imls-open-sci/ucla-imls-open-sci.github.io/issues/new?template=pilot-report.yml) afterward. Browse the lessons first on the [pilot page](https://ucla-imls-open-sci.info/pilot/).
 
   - type: input
     id: name
     attributes:
       label: Name
-      description: Your name
+      description: As you'd like it to appear if we credit you
       placeholder: Jane Doe
     validations:
       required: true
@@ -37,6 +40,24 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: github
+    attributes:
+      label: GitHub username
+      description: So we can tag you in coordination threads (optional)
+      placeholder: "@jdoe"
+    validations:
+      required: false
+
+  - type: input
+    id: orcid
+    attributes:
+      label: ORCID
+      description: Used to credit you on the lesson page and in project outputs (optional)
+      placeholder: 0000-0000-0000-0000
+    validations:
+      required: false
+
   - type: dropdown
     id: lesson
     attributes:
@@ -44,20 +65,44 @@ body:
       multiple: true
       options:
         - A Path to Open, Inclusive, and Collaborative Science for Librarians
-        - Data Management (and Sharing) Plans for Librarians 101
-        - Open Qualitative Research
         - Authoring Open Science
+        - Cloud Workflows for Librarians
         - Containers and Virtual Machines
-        - ORCID for Librarians
-        - Open Science Team Agreements
-        - Open Science Discovery Engines
-        - Data Dashboards with R
-        - Open Research Cloud Workflows
+        - Creating Data Dashboards with R
+        - Data Management (and Sharing) Plans for Librarians 101
+        - Multilingual Search and Discovery
+        - NASA SciX for Librarians
+        - Open Qualitative Research (QualCoder)
+        - Open Qualitative Research (Taguette)
+        - Open Science Community of Practice
         - Open Science Hardware
-        - Collaborative Multilingual Search and Discovery Systems
+        - Open Science Team Agreements
+        - ORCID for Librarians
         - Reproducible Research Workflows
+        - Not sure yet — open to suggestions
     validations:
       required: true
+
+  - type: textarea
+    id: coinstructors
+    attributes:
+      label: Co-instructors
+      description: Names (and GitHub usernames, if known) of anyone teaching with you
+      placeholder: "Jesse Sadler (@jessesadler)"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: carpentries_experience
+    attributes:
+      label: Carpentries teaching experience
+      options:
+        - Certified Carpentries instructor
+        - Have taught Carpentries-style workshops before
+        - New to teaching Carpentries lessons
+        - Prefer not to say
+    validations:
+      required: false
 
   - type: dropdown
     id: format
@@ -84,8 +129,8 @@ body:
     id: timing
     attributes:
       label: Tentative timing
-      description: Approximate timeframe for the pilot
-      placeholder: Fall 2025, Spring 2026, etc.
+      description: Approximate timeframe, or a target date if you have one
+      placeholder: Summer 2026, or "2026-08-20"
     validations:
       required: false
 
@@ -93,6 +138,16 @@ body:
     id: notes
     attributes:
       label: Additional notes or questions
-      description: Anything else you’d like us to know
+      description: Anything else you'd like us to know
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: consent
+    attributes:
+      label: Crediting
+      description: Pilot instructors are credited on the lesson page, in a Carpentries blog post, and in any future publications that reference the curriculum
+      options:
+        - label: Yes, you may credit me (name and affiliation) as a pilot instructor
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/pilot-report.yml
+++ b/.github/ISSUE_TEMPLATE/pilot-report.yml
@@ -35,17 +35,19 @@ body:
       label: Lesson taught
       options:
         - A Path to Open, Inclusive, and Collaborative Science for Librarians
-        - Data Management (and Sharing) Plans for Librarians 101
-        - Open Qualitative Research
         - Authoring Open Science
+        - Cloud Workflows for Librarians
         - Containers and Virtual Machines
-        - ORCID for Librarians
-        - Open Science Team Agreements
-        - Open Science Discovery Engines
-        - Data Dashboards with R
-        - Open Research Cloud Workflows
+        - Creating Data Dashboards with R
+        - Data Management (and Sharing) Plans for Librarians 101
+        - Multilingual Search and Discovery
+        - NASA SciX for Librarians
+        - Open Qualitative Research (QualCoder)
+        - Open Qualitative Research (Taguette)
+        - Open Science Community of Practice
         - Open Science Hardware
-        - Collaborative Multilingual Search and Discovery Systems
+        - Open Science Team Agreements
+        - ORCID for Librarians
         - Reproducible Research Workflows
     validations:
       required: true

--- a/.github/workflows/add-pilots-to-project.yml
+++ b/.github/workflows/add-pilots-to-project.yml
@@ -1,0 +1,23 @@
+name: Add pilot issues to project
+
+# Adds any issue labeled `pilot` or `pilot-report` to the Open Science Pilots
+# project board (https://github.com/orgs/ucla-imls-open-sci/projects/1) so the
+# pilot lifecycle can be tracked in one place.
+#
+# Requires a repo or org secret `ADD_TO_PROJECT_PAT`: a fine-grained or classic
+# PAT with `project` scope (the default GITHUB_TOKEN cannot write org projects).
+
+on:
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/ucla-imls-open-sci/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: pilot, pilot-report
+          label-operator: OR

--- a/communications/pilot-coordination.md
+++ b/communications/pilot-coordination.md
@@ -77,12 +77,14 @@ Tim
 | #56 | Christine Turner | ORCID for Librarians | Levi Dolan, Mirian Ramirez, Hannah Craven | ✅ | ✅ |
 | #55 | Renee Ng | Cloud Workflows | Daniel Kerchner | ✅ | ✅ |
 | #54 | Renee Ng | Data Dashboards with R | Aditya Ranganath | ✅ | ✅ |
-| #67 | Eric Toole | Reproducible Research Workflows (+ 3 more TBD summer 2026) | Agata Bochynska | ✅ | ⏳ |
+| #67 | Eric Toole | Reproducible Research Workflows (+ 3 more TBD summer 2026) | Agata Bochynska | ✅ | ✅ [lc-reproducible-research#6](https://github.com/LibraryCarpentry/lc-reproducible-research/issues/6) |
 | #64 | Jennifer Stubbs | DMP 101 | Lena Bohman, Marla Hertz, Daria Orlowska | ✅ | ✅ |
-| #65 | Hannah Sutherland | DMP 101 | Lena Bohman, Marla Hertz, Daria Orlowska | ⏳ | ⏳ |
-| #66 | Rachel Caldwell | Authoring Open Science | Kathryn Miller, Andrea Medina-Smith | ⏳ | ⏳ |
-| #68 | Jennifer Chaput | A Path to Open | Irene Vazano, Jessica Formoso | ⏳ | ⏳ |
-| #69 | Brendan Kelly | Containers and Virtual Machines | Fernando Rios, Jeffrey Oliver (U. Arizona) | ⏳ | ⏳ |
+| #65 | Hannah Sutherland | DMP 101 | Lena Bohman, Marla Hertz, Daria Orlowska | ✅ | ✅ |
+| #66 | Rachel Caldwell | Authoring Open Science | Kathryn Miller, Andrea Medina-Smith | ⏳ needs author emails | ✅ [lc-authoring-open-science#11](https://github.com/ucla-imls-open-sci/lc-authoring-open-science/issues/11) |
+| #68 | Jennifer Chaput | A Path to Open | Irene Vazano, Jessica Formoso | ⏳ needs author emails | ✅ [lc-collaborative-science#7](https://github.com/LibraryCarpentry/lc-collaborative-science/issues/7) |
+| #69 | Brendan Kelly | Containers and Virtual Machines | Fernando Rios, Jeffrey Oliver (U. Arizona) | ⏳ needs author emails | ✅ [lc-containers_vms#32](https://github.com/LibraryCarpentry/lc-containers_vms/issues/32) |
+| #70 | Emily Blumenthal | Open Qualitative Research (QualCoder) | Nathaniel Porter, Sebastian Karcher | ✅ 2026-06-15 | ✅ [lc-qualitative-qualcoder#25](https://github.com/LibraryCarpentry/lc-qualitative-qualcoder/issues/25) |
+| #71 | Juliet Cohen, Seth Erickson, Jairo Melo-Flórez (Jose Niño Muriel, helper) | Containers and Virtual Machines | Fernando Rios, Jeffrey Oliver (U. Arizona) | ✅ 2026-06-15 | ✅ [lc-containers_vms#35](https://github.com/LibraryCarpentry/lc-containers_vms/issues/35) |
 
 ---
 
@@ -122,6 +124,34 @@ Questions? Comment here and @jt14den.
 
 ## Resources & Notes
 
+### Author Contacts (from lesson repo commit history, 2026-06-15)
+
+| Author | Lesson | GitHub | Email |
+|--------|--------|--------|-------|
+| Jeff Oliver | Containers & VMs | @jcoliver | jcoliver@arizona.edu |
+| Fernando Rios | Containers & VMs | @zoidy | not public |
+| Nathaniel Porter | QualCoder / Taguette | @ndporter | ndporter@vt.edu |
+| Sebastian Karcher | QualCoder / Taguette | @adam3smith | karcher@u.northwestern.edu (was skarcher@syr.edu; appears to have moved to Northwestern, confirm) |
+| Jessica Formoso | A Path to Open | @JFormoso | jesica.formoso@gmail.com |
+| Irene Vazano | A Path to Open | @4iro | not public |
+| Kathryn Miller, Andrea Medina-Smith | Authoring Open Science | n/a | not found (only jt14den has committed to lc-authoring-open-science) |
+
+### Piloter Credit (GitHub/ORCID)
+
+The pilot-interest issue template now collects GitHub and ORCID at signup (as of the intake update on this branch), but that data doesn't flow anywhere automatically — transcribe it here, then into the lesson YAML `pilots[].instructors[]` field, for every new pilot.
+
+| Piloter | Lesson | GitHub | ORCID |
+|---------|--------|--------|-------|
+| Jennifer Stubbs | DMP 101 | @jas58 | 0000-0002-6080-5703 |
+| Juliet Cohen | Containers & VMs | @julietcohen | 0000-0001-8217-4028 |
+| Seth Erickson | Containers & VMs | @srerickson | 0000-0002-5570-7201 |
+| Jairo Melo-Flórez | Containers & VMs | @jairomelo | 0000-0002-2020-1163 |
+| Hafeez Adepoju | Containers & VMs (RDAP) | not confirmed | not confirmed |
+| Chreston Miller | Containers & VMs (RDAP) | not confirmed | not confirmed |
+| Jose Niño Muriel | Containers & VMs (helper) | not confirmed | not confirmed |
+
+Still need to ask Hafeez, Chreston, and Jose directly for GitHub/ORCID — couldn't confirm via web search, don't want to guess wrong on an identifier.
+
 ### Carpentries Links
 - Pilot observation notes: https://codimd.carpentries.org/lesson-pilot-observation-notes-template
 - Post-workshop survey: https://carpentries.github.io/assessment-archives/post-workshop/post-workshop.html
@@ -135,3 +165,33 @@ Questions? Comment here and @jt14den.
 - ORCID lesson: Currently pre-alpha; authors need to assess readiness during briefing.
 - Containers and VMs: Now in Beta. Repo moved to LibraryCarpentry/lc-containers_vms (was UAL-RE). Authors: Fernando Rios, Jeffrey Oliver (U. Arizona). Beta pilot at RDAP Summit April 13, 2026.
 - Rachel Caldwell (#66): Co-piloting Authoring Open Science with Nicky Garland (#62) — connect them in the intro email.
+
+---
+
+## June 2026 Correspondence
+
+### 2026-06-01 — Evaluation survey (Christine Turner + Eric Toole, UMass)
+
+**Incoming:** Christine Turner (cturner@library.umass.edu), cc Eric Toole (etoole@umass.edu) — asked whether we send a post-workshop survey and if they could use ours as a model. UMass is planning alpha carpentries pilots in June and July and wants an evaluation form for participants.
+
+**Sent:**
+
+Christine & Eric,
+
+We sent the pre-workshop survey but skipped the post-workshop one. For pilots, the Carpentries lesson development training has a feedback collection section that covers observer notes, minute cards, and end-of-session surveys. There's a template included:
+
+https://carpentries.github.io/lesson-development-training/preparing.html#feedback-collection-plan
+
+We also have a pilot evaluation form if you want something to compare it to:
+
+https://docs.google.com/forms/d/1OGCQBotD2nOJkc7KpFZLhFfb3EBcxEDwHz_3p48qz3U/template/preview
+
+Tim
+
+### 2026-06-15 — Two new pilots to action
+
+**#71 Juliet Cohen, Seth Erickson, Jairo Melo-Flórez (UCSB), Containers & VMs** — workshop held July 15, 2026, 10am-1pm PT, in-person (3-hour single session, Carpentry @ UCSB Library): https://carpentry.library.ucsb.edu/workshop/2026/07/15/ucsb-containers/. Jose Niño Muriel is listed as helper, not lead instructor (corrects earlier note). Action: comment on #71, open coordination issue on `LibraryCarpentry/lc-containers_vms` connecting the team to authors Fernando Rios and Jeffrey Oliver.
+
+**#70 Emily Blumenthal (GWU), QualCoder** — replied 2026-05-20; already ran a 1-hour QualCoder overview with strong interest from Schools of Medicine and Public Health, wants a full 1-day session end of August 2026, ready to coordinate with authors. Waiting on author intro. Action: comment on #70, open coordination issue on `LibraryCarpentry/open-qualitative-research-qualcoder` connecting her to Nathaniel Porter (@ndporter) and Sebastian Karcher.
+
+**First completed pilot — feedback in:** lc-dmp101#19 (Jennifer Stubbs, Bradley) held the DMP 101 workshop May 19. Substantial feedback through June 9: timing overran (covered 2 of 5 sections), plus content asks — add NSF DMSP webform (NSF 26-202, required as of Apr 27 2026), NIH form updates, consolidated jargon glossary, less US-centric examples, README resource. Route to DMP 101 authors (Bohman, Hertz, Orlowska).

--- a/src/content/blog/2026-04-03-pilot-update.md
+++ b/src/content/blog/2026-04-03-pilot-update.md
@@ -18,7 +18,7 @@ In January we [put out a call for community pilots](/blog/2026-01-05-carpentries
 Here's who's teaching what:
 
 <div class="table-responsive">
-<table class="content-table">
+<table class="table table-hover">
   <thead>
     <tr><th>Lesson</th><th>Instructor</th><th>Institution</th></tr>
   </thead>

--- a/src/content/blog/2026-05-19-pilots-first-results.md
+++ b/src/content/blog/2026-05-19-pilots-first-results.md
@@ -26,24 +26,27 @@ Thank you to the instructors who ran sessions and took the time to report back:
     <tr><th>Lesson</th><th>Instructor(s)</th><th>Institution</th><th>Date</th></tr>
   </thead>
   <tbody>
-    <tr><td>Containers and Virtual Machines</td><td>Fernando Rios &amp; Jeffrey Oliver</td><td>University of Arizona</td><td>Oct 2024, Jun 2025</td></tr>
+    <tr><td>Containers and Virtual Machines</td><td><a href="https://orcid.org/0000-0001-6262-3260">Fernando Rios</a> &amp; <a href="https://orcid.org/0000-0003-2160-1086">Jeffrey Oliver</a></td><td>University of Arizona</td><td>Oct 2024, Jun 2025</td></tr>
     <tr><td>Containers and Virtual Machines</td><td>Hafeez Adepoju &amp; Chreston Miller</td><td>University of Arizona / Virginia Tech</td><td>Apr 2026 (RDAP Summit)</td></tr>
-    <tr><td>Data Dashboards with R</td><td>Aditya Ranganath</td><td>CU Boulder (CRDDS)</td><td>May 2025</td></tr>
-    <tr><td>Data Dashboards with R</td><td>Nathaniel Porter &amp; Jesse Sadler</td><td>Virginia Tech</td><td>Spring 2026</td></tr>
-    <tr><td>Open Qualitative Research (QualCoder)</td><td>Nathaniel Porter</td><td>Virginia Tech</td><td>Mar &amp; May 2025</td></tr>
-    <tr><td>Open Qualitative Research (QualCoder)</td><td>Sebastian Karcher</td><td>IASSIST 2025, Bristol UK</td><td>Jun 2025</td></tr>
-    <tr><td>DMP 101</td><td>Jennifer Stubbs</td><td>Bradley University / CARLI</td><td>May 2026</td></tr>
+    <tr><td>Data Dashboards with R</td><td><a href="https://orcid.org/0000-0003-1272-6354">Aditya Ranganath</a></td><td>CU Boulder (CRDDS)</td><td>May 2025</td></tr>
+    <tr><td>Data Dashboards with R</td><td><a href="https://orcid.org/0000-0002-0479-6777">Nathaniel Porter</a> &amp; Jesse Sadler</td><td>Virginia Tech</td><td>Spring 2026</td></tr>
+    <tr><td>Open Qualitative Research (QualCoder)</td><td><a href="https://orcid.org/0000-0002-0479-6777">Nathaniel Porter</a></td><td>Virginia Tech</td><td>Mar &amp; May 2025</td></tr>
+    <tr><td>Open Qualitative Research (QualCoder)</td><td><a href="https://orcid.org/0000-0001-8249-7388">Sebastian Karcher</a></td><td>IASSIST 2025, Bristol UK</td><td>Jun 2025</td></tr>
+    <tr><td>DMP 101</td><td><a href="https://orcid.org/0000-0002-6080-5703">Jennifer Stubbs</a> (<a href="https://github.com/jas58">GitHub</a>)</td><td>Bradley University / CARLI</td><td>May 2026</td></tr>
+    <tr><td>Containers and Virtual Machines</td><td><a href="https://orcid.org/0000-0001-8217-4028">Juliet Cohen</a>, <a href="https://orcid.org/0000-0002-5570-7201">Seth Erickson</a> &amp; <a href="https://orcid.org/0000-0002-2020-1163">Jairo Melo-Flórez</a></td><td><a href="https://carpentry.library.ucsb.edu/workshop/2026/07/15/ucsb-containers/">UC Santa Barbara</a></td><td>Jul 2026</td></tr>
   </tbody>
 </table>
 </div>
 
-Seven external community pilots across four lessons. Institutions in Illinois, Colorado, Arizona, Virginia, and the UK.
+Eight external community pilots across four lessons. Institutions in Illinois, Colorado, Arizona, Virginia, California, and the UK.
+
+None of this happens without lesson authors willing to hand their material to someone else and let it get picked apart: thanks to [Fernando Rios](https://orcid.org/0000-0001-6262-3260), [Jeffrey Oliver](https://orcid.org/0000-0003-2160-1086), [Aditya Ranganath](https://orcid.org/0000-0003-1272-6354), [Nathaniel Porter](https://orcid.org/0000-0002-0479-6777), [Sebastian Karcher](https://orcid.org/0000-0001-8249-7388), [Lena Bohman](https://orcid.org/0000-0002-0505-7036), [Marla Hertz](https://orcid.org/0000-0001-7929-7756), and [Daria Orlowska](https://orcid.org/0000-0003-3497-7103) for opening their lessons to outside testing.
 
 ## What the Feedback Looks Like
 
 Nathaniel Porter's post-pilot notes on Data Dashboards with R ran to 20 specific items: timing estimates that were off, accessibility language to fix, screenshot quality issues, a code block with a logic error. The kind of review that doesn't come from the people who wrote the lesson. Lesson author Aditya Ranganath is working through the list.
 
-Jennifer Stubbs is teaching DMP101 today at Bradley University through CARLI. During prep she flagged two live funder policy changes the lesson needs to address: NSF 26-202 (a new required DMP template with 8 defined subsections, effective April 27, 2026) and an updated NIH Data Management and Sharing form. She also posted her full rehearsal timings. In practice the lesson runs about 100 minutes across five episodes, which is useful for anyone planning their session length.
+Jennifer Stubbs taught DMP 101 on May 19 at Bradley University through CARLI. During prep she flagged two live funder policy changes the lesson needs to address: NSF 26-202 (a new required DMP template with 8 defined subsections, effective April 27, 2026) and an updated NIH Data Management and Sharing form. In the session, episode 1 ran 40 minutes and episode 2 ran 45. She barely reached episode 3 in two hours. The discussion ran long. She didn't follow the script closely, but a notetaker said it sounded natural throughout.
 
 Sebastian Karcher took QualCoder to IASSIST 2025 in Bristol. The lesson has now been taught in the US and the UK, by two different instructors, to different audience types. That range is what moves a lesson from Alpha to Beta.
 

--- a/src/content/blog/2026-05-19-pilots-first-results.md
+++ b/src/content/blog/2026-05-19-pilots-first-results.md
@@ -21,7 +21,7 @@ In January we [called for pilots](/blog/2026-01-05-carpentries-pilot-call). In A
 Thank you to the instructors who ran sessions and took the time to report back:
 
 <div class="table-responsive">
-<table class="content-table">
+<table class="table table-hover">
   <thead>
     <tr><th>Lesson</th><th>Instructor(s)</th><th>Institution</th><th>Date</th></tr>
   </thead>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -39,7 +39,15 @@ const lessons = defineCollection({
       z.object({
         date: z.date().or(z.string()).optional(), // Date might be string in yaml if not iso
         location: z.string().optional(),
-        instructor: z.string().optional(),
+        instructor: z.string().optional(), // legacy plain-text fallback
+        instructors: z.array(
+          z.object({
+            name: z.string(),
+            orcid: z.string().optional(),
+            github: z.string().optional(),
+            role: z.enum(['instructor', 'helper']).optional(), // defaults to instructor
+          })
+        ).optional(), // structured, linkable credit
         type: z.string().optional(),
         note: z.string().optional(),
       })

--- a/src/content/lessons/a-gentle-hands-on-introduction-to-containers-and-virtual-machines.yaml
+++ b/src/content/lessons/a-gentle-hands-on-introduction-to-containers-and-virtual-machines.yaml
@@ -2,9 +2,9 @@ name: A gentle, hands-on introduction to containers and virtual machines
 duration: 3h 00m
 authors:
   - name: Fernando Rios
-    orcid: "0000-0001-5144-6764"
+    orcid: "0000-0001-6262-3260"
   - name: Jeffrey Oliver
-    orcid: "0000-0003-1249-1473"
+    orcid: "0000-0003-2160-1086"
 status: beta
 status_note: >-
   Ready for community piloting. Accepted for presentation at the RDAP Summit on
@@ -18,17 +18,61 @@ pilots:
   - date: 2024-10-10T00:00:00.000Z
     location: University of Arizona
     instructor: Fernando Rios & Jeffrey Oliver
+    instructors:
+      - name: Fernando Rios
+        orcid: "0000-0001-6262-3260"
+        role: instructor
+      - name: Jeffrey Oliver
+        orcid: "0000-0003-2160-1086"
+        role: instructor
     type: Alpha Pilot
   - date: 2025-06-05T00:00:00.000Z
     location: University of Arizona
     instructor: Fernando Rios & Jeffrey Oliver
+    instructors:
+      - name: Fernando Rios
+        orcid: "0000-0001-6262-3260"
+        role: instructor
+      - name: Jeffrey Oliver
+        orcid: "0000-0003-2160-1086"
+        role: instructor
     type: Alpha Pilot
     note: Initial test session.
   - date: 2026-04-13T00:00:00.000Z
     location: RDAP Summit 2026
     instructor: Hafeez Adepoju (University of Arizona) & Chreston Miller (Virginia Tech)
+    instructors:
+      - name: Hafeez Adepoju
+        role: instructor
+      - name: Chreston Miller
+        role: instructor
     type: Beta Pilot
-    note: Workshop at the RDAP Summit.
+    note: >-
+      Workshop at the RDAP Summit. TODO: Hafeez's and Chreston's ORCID/GitHub
+      not yet confirmed — ask Tim.
+  - date: 2026-07-15T00:00:00.000Z
+    location: UC Santa Barbara (Carpentry @ UCSB Library)
+    instructor: Juliet Cohen, Seth Erickson & Jairo Melo-Flórez
+    instructors:
+      - name: Juliet Cohen
+        orcid: "0000-0001-8217-4028"
+        github: julietcohen
+        role: instructor
+      - name: Seth Erickson
+        orcid: "0000-0002-5570-7201"
+        github: srerickson
+        role: instructor
+      - name: Jairo Melo-Flórez
+        orcid: "0000-0002-2020-1163"
+        github: jairomelo
+        role: instructor
+      - name: Jose Niño Muriel
+        role: helper
+    type: Community Pilot
+    note: >-
+      3-hour in-person session, 10am-1pm PT.
+      https://carpentry.library.ucsb.edu/workshop/2026/07/15/ucsb-containers/
+      TODO: Jose's ORCID/GitHub not yet confirmed — ask Tim.
 learningResourceType: lesson
 teaches:
   - Using containers

--- a/src/content/lessons/a-path-to-open-inclusive-and-collaborative-science-for-librarians.yaml
+++ b/src/content/lessons/a-path-to-open-inclusive-and-collaborative-science-for-librarians.yaml
@@ -2,7 +2,7 @@ name: A Path to Open, Inclusive, and Collaborative Science for Librarians
 duration: 3h 0m
 authors:
   - name: Irene Vazano
-    orcid: "0009-0005-7764-747X"
+    orcid: "0000-0002-0912-2501"
   - name: Jessica Formoso
     orcid: "0000-0002-3112-9118"
 contributors: []

--- a/src/content/lessons/authoring-open-science.yaml
+++ b/src/content/lessons/authoring-open-science.yaml
@@ -2,8 +2,9 @@ name: Authoring Open Science
 duration: 3h 00m
 authors:
   - name: Kathryn Miller
+    orcid: "0000-0001-8005-089X"
   - name: Andrea Medina-Smith
-    orcid: "0000-0002-1463-5460"
+    orcid: "0000-0002-1217-701X"
 status: alpha
 educationalLevel: Introductory
 abstract: >-

--- a/src/content/lessons/building-an-open-science-community-of-practice.yaml
+++ b/src/content/lessons/building-an-open-science-community-of-practice.yaml
@@ -2,7 +2,7 @@ name: Building an Open Science Community of Practice
 duration: 90m
 authors:
   - name: Camille Thomas
-    orcid: "0000-0001-7053-1596"
+    orcid: "0000-0002-0363-0126"
 status: pre-alpha
 educationalLevel: Introductory
 abstract: >-

--- a/src/content/lessons/collaborative-multilingual-search-and-discovery-systems.yaml
+++ b/src/content/lessons/collaborative-multilingual-search-and-discovery-systems.yaml
@@ -2,9 +2,9 @@ name: Collaborative Multilingual Search and Discovery Systems
 duration: 3h 00m
 authors:
   - name: Eric Silberberg
-    orcid: "0000-0002-4779-119X"
+    orcid: "0000-0002-2216-7632"
   - name: Jesus Alonso-Regalado
-    orcid: "0000-0002-4813-1628"
+    orcid: "0000-0002-3294-2292"
   - name: Cate Kellett
     orcid: "0000-0001-7667-8730"
 status: alpha

--- a/src/content/lessons/creating-data-dashboards-for-open-science-using-the-r-programming-language.yaml
+++ b/src/content/lessons/creating-data-dashboards-for-open-science-using-the-r-programming-language.yaml
@@ -2,7 +2,7 @@ name: Creating Data Dashboards for Open Science Using the R Programming Language
 duration: 3h 36m
 authors:
   - name: Aditya Ranganath
-    orcid: "0000-0001-9799-5231"
+    orcid: "0000-0003-1272-6354"
 status: alpha
 educationalLevel: Intermediate
 abstract: >-

--- a/src/content/lessons/data-management-and-sharing-plans-for-librarians-101.yaml
+++ b/src/content/lessons/data-management-and-sharing-plans-for-librarians-101.yaml
@@ -1,11 +1,11 @@
 name: Data Management (and Sharing) Plans for Librarians 101
 authors:
   - name: Lena Bohman
-    orcid: "0000-0002-0943-9844"
+    orcid: "0000-0002-0505-7036"
   - name: Marla Hertz
-    orcid: "0000-0002-7634-1188"
+    orcid: "0000-0001-7929-7756"
   - name: Daria Orlowska
-    orcid: "0000-0002-9907-2856"
+    orcid: "0000-0003-3497-7103"
 status: beta
 library_carpentry_adopted: true
 educationalLevel: Introductory
@@ -21,9 +21,34 @@ keywords:
 pilots:
   - date: 2024-03-14T00:00:00.000Z
     location: Internal (UCLA/Authors)
-    instructor: Authors
+    instructor: Lena Bohman, Marla Hertz & Daria Orlowska
+    instructors:
+      - name: Lena Bohman
+        orcid: "0000-0002-0943-9844"
+        role: instructor
+      - name: Marla Hertz
+        orcid: "0000-0002-7634-1188"
+        role: instructor
+      - name: Daria Orlowska
+        orcid: "0000-0002-9907-2856"
+        role: instructor
     type: Internal Alpha Pilot
     note: Initial internal run; went smoothly.
+  - date: 2026-05-19T00:00:00.000Z
+    location: Bradley University (CARLI)
+    instructor: Jennifer Stubbs
+    instructors:
+      - name: Jennifer Stubbs
+        orcid: "0000-0002-6080-5703"
+        github: jas58
+        role: instructor
+    type: Community Pilot
+    note: >-
+      Episode 1 ran 40 min, episode 2 ran 45 min; barely reached episode 3 in
+      two hours. Discussion was engaged and ran long. Flagged NSF 26-202 (new
+      8-section required DMP template, effective April 27, 2026) and updated NIH
+      Data Management and Sharing form as live policy changes needing lesson
+      updates.
 recognition:
   - title: Library Carpentry Adoption
     desc: Formally adopted as an official Library Carpentry lesson.

--- a/src/content/lessons/leveraging-open-research-and-contributor-ids-orcid-for-librarians.yaml
+++ b/src/content/lessons/leveraging-open-research-and-contributor-ids-orcid-for-librarians.yaml
@@ -4,9 +4,9 @@ authors:
   - name: Levi Dolan
     orcid: "0000-0002-7476-8012"
   - name: Mirian Ramirez
-    orcid: "0000-0001-7151-512X"
+    orcid: "0000-0002-6233-7480"
   - name: Hannah Craven
-    orcid: "0000-0002-2121-6150"
+    orcid: "0000-0002-1701-3655"
 status: pre-alpha
 educationalLevel: Introductory
 abstract: >-

--- a/src/content/lessons/open-and-reproducible-research-cloud-workflows-a-firsthand-experience-for-librarians.yaml
+++ b/src/content/lessons/open-and-reproducible-research-cloud-workflows-a-firsthand-experience-for-librarians.yaml
@@ -4,7 +4,7 @@ name: >-
 duration: 3h 08m
 authors:
   - name: Daniel Kerchner
-    orcid: "0000-0001-8314-8742"
+    orcid: "0000-0002-5921-2193"
 status: alpha
 educationalLevel: Intermediate
 why_teach: >-

--- a/src/content/lessons/open-qualitative-research-taguette.yaml
+++ b/src/content/lessons/open-qualitative-research-taguette.yaml
@@ -17,10 +17,18 @@ pilots:
   - date: 2025-04-03T00:00:00.000Z
     location: Co-taught Workshop
     instructor: Sebastian Karcher
+    instructors:
+      - name: Sebastian Karcher
+        orcid: "0000-0001-8249-7388"
+        role: instructor
     type: Co-taught Pilot
   - date: 2025-04-01T00:00:00.000Z
     location: External Pilot
-    instructor: Authors
+    instructor: Nathaniel Porter
+    instructors:
+      - name: Nathaniel Porter
+        orcid: "0000-0002-0479-6777"
+        role: instructor
     type: Pilot
     note: Taught twice using data from QDR.
 learningResourceType: lesson

--- a/src/content/lessons/open-science-discovery-engines-empowering-librarian-use-through-a-case-study-exploration-of-the-nasa-science-explorer.yaml
+++ b/src/content/lessons/open-science-discovery-engines-empowering-librarian-use-through-a-case-study-exploration-of-the-nasa-science-explorer.yaml
@@ -4,11 +4,11 @@ name: >-
 duration: 4h 15m
 authors:
   - name: Jennifer Lynn Bartlett
-    orcid: "0000-0002-5364-5415"
+    orcid: "0000-0001-7394-4545"
   - name: Katie Frey
-    orcid: "0000-0003-0104-5853"
+    orcid: "0000-0001-9891-4465"
   - name: Stephanie Jarmak
-    orcid: "0000-0002-1241-1187"
+    orcid: "0000-0002-6982-7191"
 contributors:
   - Tim Dennis
   - Zikang Eric Huang

--- a/src/content/lessons/open-science-hardware-an-introduction-for-librarians.yaml
+++ b/src/content/lessons/open-science-hardware-an-introduction-for-librarians.yaml
@@ -1,7 +1,7 @@
 name: 'Open science hardware: an introduction for librarians'
 authors:
   - name: Julieta Arancio
-    orcid: "0000-0002-4015-8418"
+    orcid: "0000-0002-8624-4182"
 status: alpha
 educationalLevel: Introductory
 abstract: >-

--- a/src/content/lessons/reproducible-research-workflows.yaml
+++ b/src/content/lessons/reproducible-research-workflows.yaml
@@ -1,7 +1,7 @@
 name: Reproducible Research Workflows
 authors:
   - name: Agata Bochynska
-    orcid: "0000-0002-4148-3561"
+    orcid: "0000-0001-6211-8600"
 status: pre-alpha
 educationalLevel: Intermediate
 abstract: >-

--- a/src/content/lessons/research-community-outreach-with-open-science-team-agreements.yaml
+++ b/src/content/lessons/research-community-outreach-with-open-science-team-agreements.yaml
@@ -2,11 +2,11 @@ name: Research Community Outreach with Open Science Team Agreements
 duration: 2h 15m
 authors:
   - name: Samantha Teplitzky
-    orcid: "0000-0001-9071-7080"
+    orcid: "0000-0001-7071-332X"
   - name: Ariel Deardorff
     orcid: "0000-0001-8930-6089"
   - name: Samantha Wilairat
-    orcid: "0000-0003-0365-9509"
+    orcid: "0000-0002-5836-4523"
 status: alpha
 educationalLevel: Introductory
 abstract: >-

--- a/src/pages/lessons/[slug].astro
+++ b/src/pages/lessons/[slug].astro
@@ -127,6 +127,19 @@ const jsonLd = {
       ...(a.orcid ? { sameAs: `https://orcid.org/${a.orcid}` } : {}),
     }))
   } : {}),
+  ...(lesson.pilots?.some((p: any) => p.instructors?.some((i: any) => i.orcid)) ? {
+    contributor: Array.from(
+      new Map(
+        lesson.pilots.flatMap((p: any) => p.instructors || [])
+          .filter((i: { orcid?: string }) => i.orcid)
+          .map((i: { name: string; orcid?: string }) => [i.orcid, i])
+      ).values()
+    ).map((i: any) => ({
+      '@type': 'Person',
+      name: i.name,
+      sameAs: `https://orcid.org/${i.orcid}`,
+    }))
+  } : {}),
   ...(health?.pushedAt ? { dateModified: health.pushedAt } : {}),
   ...(lesson.doi ? { identifier: `https://doi.org/${lesson.doi}` } : {}),
   inLanguage: 'en',
@@ -233,6 +246,13 @@ const jsonLd = {
           {lesson.pilots && lesson.pilots.length > 0 && (
             <div class="mt-5">
                 <h4><i class="fas fa-history mr-2 text-muted"></i>Workshop History</h4>
+                {lesson.authors && lesson.authors.length > 0 && (
+                    <p class="text-muted small mb-3">
+                        Piloting is what moves a lesson past what the authors can test alone.
+                        Thanks to {lesson.authors.map((a: { name: string }) => a.name).join(', ')} for
+                        opening this lesson to outside review.
+                    </p>
+                )}
                 <div class="table-responsive">
                     <table class="table table-hover table-sm mt-3">
                         <thead class="thead-light">
@@ -249,7 +269,29 @@ const jsonLd = {
                                     <td>{new Date(pilot.date).toLocaleDateString()}</td>
                                     <td>{pilot.location}</td>
                                     <td><span class="badge badge-light border">{pilot.type}</span></td>
-                                    <td>{pilot.instructor}</td>
+                                    <td>
+                                        {pilot.instructors && pilot.instructors.length > 0 ? (
+                                            pilot.instructors.map((person: { name: string; orcid?: string; github?: string; role?: string }, idx: number) => (
+                                                <span class="mr-2 d-inline-block">
+                                                    {idx > 0 && <span class="mr-2">·</span>}
+                                                    {person.name}
+                                                    {person.role === 'helper' && <span class="badge badge-light border ml-1" style="font-size: 0.7rem;">helper</span>}
+                                                    {person.orcid && (
+                                                        <a href={`https://orcid.org/${person.orcid}`} target="_blank" rel="noopener noreferrer" class="ml-1" aria-label={`ORCID for ${person.name}`}>
+                                                            <i class="fab fa-orcid text-success"></i>
+                                                        </a>
+                                                    )}
+                                                    {person.github && (
+                                                        <a href={`https://github.com/${person.github}`} target="_blank" rel="noopener noreferrer" class="ml-1" aria-label={`GitHub for ${person.name}`}>
+                                                            <i class="fab fa-github text-dark"></i>
+                                                        </a>
+                                                    )}
+                                                </span>
+                                            ))
+                                        ) : (
+                                            pilot.instructor
+                                        )}
+                                    </td>
                                 </tr>
                             ))}
                         </tbody>


### PR DESCRIPTION
Reworks the pilot intake based on the ~18 interest submissions received since the February call.

**pilot-interest.yml**
- Split Open Qualitative Research into QualCoder and Taguette (a recurring point of confusion)
- Aligned lesson names to the pilot page; one canonical 15-lesson list
- Added optional fields: GitHub username, ORCID, co-instructors, Carpentries teaching experience, and a credit-consent checkbox
- Clearer intro explaining what a pilot is and what happens next; dropped the title placeholder that left many issues with blank titles

**pilot-report.yml**
- Synced the lesson dropdown to the same canonical list

**add-pilots-to-project.yml**
- Auto-adds issues labeled `pilot` or `pilot-report` to org project #1
- Requires a repo/org secret `ADD_TO_PROJECT_PAT` (PAT with project scope)

Project #1 already has matching fields (Pilot stage, Lesson, Institution, Target date).