### PR TITLE
Log Nathaniel Porter & Jesse Sadler's Data Dashboards pilot

### DIFF
--- a/src/content/lessons/creating-data-dashboards-for-open-science-using-the-r-programming-language.yaml
+++ b/src/content/lessons/creating-data-dashboards-for-open-science-using-the-r-programming-language.yaml
@@ -23,6 +23,21 @@ pilots:
     location: CRDDS, CU Boulder
     instructor: Aditya Ranganath
     type: Virtual Workshop
+  - date: 2026-04-01T00:00:00.000Z
+    location: Virginia Tech
+    instructor: Nathaniel Porter & Jesse Sadler
+    instructors:
+      - name: Nathaniel Porter
+        orcid: "0000-0002-0479-6777"
+        role: instructor
+      - name: Jesse Sadler
+        role: instructor
+    type: Community Pilot
+    note: >-
+      Date is approximate (April 1 used as a Spring 2026 placeholder).
+      Issue #61 gave "Spring 2026" as tentative timing with no exact date
+      on record or follow-up report filed; reported as taught in the May
+      2026 pilot-results post.
 learningResourceType: lesson
 teaches:
   - >-


### PR DESCRIPTION
## Summary
- Both blog posts already credited this pilot (Nathaniel Porter & Jesse Sadler, Virginia Tech, Spring 2026) as taught, but it was never logged in the lesson's `pilots[]` history — closing that gap.
- Exact date isn't on record (issue #61 gave only "Spring 2026" as tentative timing); April 1, 2026 is used as a placeholder, noted as such in the entry.
- Follow-up from closing pilot-interest issue #61.

## Test plan
- [x] `npm run build` passes